### PR TITLE
nokogiri >=1.13.6

### DIFF
--- a/github-pages.gemspec
+++ b/github-pages.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   end
 
   s.add_dependency("mercenary", "~> 0.3")
-  s.add_dependency("nokogiri", ">= 1.13.4", "< 2.0")
+  s.add_dependency("nokogiri", ">= 1.13.6", "< 2.0")
   s.add_dependency("terminal-table", "~> 1.4")
   s.add_development_dependency("jekyll_test_plugin_malicious", "~> 0.2")
   s.add_development_dependency("pry", "~> 0.10")

--- a/lib/github-pages/version.rb
+++ b/lib/github-pages/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GitHubPages
-  VERSION = 226
+  VERSION = 227
 end


### PR DESCRIPTION
[Security] Require nokogiri 1.13.6 or greater
